### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,5 @@ COPY docker/entrypoint.sh ./entrypoint.sh
 # Final operations
 RUN chmod +x ./entrypoint.sh
 ARG COMMIT_SHA
-ENV COMMIT_SHA ${COMMIT_SHA}
+ENV COMMIT_SHA=${COMMIT_SHA}
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]


### PR DESCRIPTION
```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 30)
```

<img width="919" alt="image" src="https://github.com/user-attachments/assets/d605255e-207b-42b6-9056-52e911517204" />
